### PR TITLE
Fix bugs from last night

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+*.mp4
+*.response

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,18 @@
+use std::cmp::min;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
+
+// On MacOS, the `write` syscall can only handle a certain number
+// of bytes at once. Anything larger will return OS Error 22,
+// i.e. EINVAL.
+// From the `man 2 write`:
+//   write() and pwrite() will fail if the parameter nbyte exceeds INT_MAX, and they do not attempt a partial
+//   write.
+// So, let's limit it to MAX_INT. I imported MAX_INT in C and printed it, and it was
+// this.
+/// Maximum number of bytes that can be written in a single `write` call.
+const MAX_WRITE_LEN: usize = i32::MAX as usize;
 
 fn handle_client(stream: TcpStream) -> Result<(), String> {
     let writer = stream.try_clone().unwrap();
@@ -42,14 +54,14 @@ fn respond<W: Write, R: BufRead>(mut writer: W, mut reader: R) -> Result<(), Str
         .map_err(|e| format!("Content-length header was not a valid number: {e}"))?;
     println!("Content length is {content_length}");
 
-    let mut first_line_sent = false;
     if let Some(v) = headers.get("Expect") {
         if v == "100-continue" {
             // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/100
-            let first_line_resp = b"HTTP/1.1 100 Continue\r\n";
+            // Note that the server must still write a final response status
+            // after it reads the HTTP body.
+            let first_line_resp = b"HTTP/1.1 100 Continue\r\n\r\n";
             let n = writer.write(first_line_resp).unwrap();
             assert_eq!(n, first_line_resp.len());
-            first_line_sent = true;
         }
     }
 
@@ -66,20 +78,18 @@ fn respond<W: Write, R: BufRead>(mut writer: W, mut reader: R) -> Result<(), Str
     let body = format!("你好 {name}");
     let body_len = body.as_bytes().len();
     let headers = format!("Content-Length: {}\r\n", body_len);
-    let msg = if first_line_sent {
-        format!("{headers}\r\n{body}")
-    } else {
-        format!("{status}\r\n{headers}\r\n{body}")
-    };
+    let msg = format!("{status}\r\n{headers}\r\n{body}");
     let msg_binary = msg.as_bytes();
-    let total_bytes = dbg!(msg_binary.len());
+    let total_bytes = msg_binary.len();
     let mut total_written = 0;
-    const MB: usize = 1_000_000;
     let mut num_writes = 0;
     while total_written < total_bytes {
-        let write_cap = std::cmp::max(MB, body_len);
+        // Don't write more than `limit` bytes at once.
+        let write_cap = min(MAX_WRITE_LEN, body_len);
+        // Don't write more bytes than remain in the body!
+        let write_cap = min(write_cap, total_bytes - total_written);
 
-        let write_fragment = &msg_binary[dbg!(total_written..write_cap)];
+        let write_fragment = &msg_binary[total_written..total_written + write_cap];
         let res = writer.write(write_fragment);
         match res {
             Ok(n) => {


### PR DESCRIPTION
Wrote two bugs last night:

1. The HTTP spec says that if the client sends `Expect: 100-continue`, the server should send a preliminary status `HTTP/1.1 100 Continue` response back, then wait for the client to send the body, then the server sends the _real_ HTTP status (e.g. 200 OK) with headers + body. Our implementation didn't send the _real_ HTTP status back, it skipped straight to sending the response headers + body.
2. Used `max` instead of `min` when trying to limit how many bytes the server would write at once.

Also, I investigated OS Error 22 more. I used `strace` to figure out which system call was causing an error (it was `write`) then looked up its manpage with `man 2 write`. It says it can only handle INT_MAX bytes in a single write, and it won't do a partial write if you write more than that, it'll just fail. On my platform, INT_MAX is (2^31) so we limit to that.